### PR TITLE
Make tests run on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.0.2",
   "main":"./index.js",
   "scripts": {
-    "test": "mocha tests/*.js -R spec"
+    "test": "mocha tests -R spec"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Windows doesn't like the wild card in the script and luckily mocha has the correct behavior by default when you just give it a folder.
