### PR TITLE
Connect to websocket on origin host instead of hardcoded localhost

### DIFF
--- a/manipulator/public/js/drawbot.js
+++ b/manipulator/public/js/drawbot.js
@@ -1,6 +1,6 @@
 var canvas = document.getElementById("robot"),
     ctx = canvas.getContext("2d"),
-    socket = io.connect('http://localhost'),
+    socket = io.connect('http://' + window.location.hostname),
     moveEE = false;
 
 socket.on('init', function (joints) {


### PR DESCRIPTION
This fix makes it so that you can run the manipulator app from a different system from the one the server is running on.
