### PR TITLE
Fix for creating square matrices and added identity property to the Matrix function

### DIFF
--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -3,24 +3,32 @@ var v = require('./vector');
 // -----------------------------------------------------------
 // Matrices
 // -----------------------------------------------------------
-var Matrix = function Matrix (rows, cols, isIdentity) {
+var Matrix = function Matrix (rows, cols) {
   // initialize the matrix
   this.rows = rows;
   this.cols = cols ? cols : rows; // make it a square matrix if only one argument
 
-  this.m = new Array(rows);
-  for (var r = 0; r < rows; ++r) {
-    this.m[r] = new Array(cols);
-    for (var c = 0; c < cols; ++c) {
+  this.m = new Array(this.rows);
+  for (var r = 0; r < this.rows; ++r) {
+    this.m[r] = new Array(this.cols);
+    for (var c = 0; c < this.cols; ++c) {
       this.m[r][c] = 0;
     }
   }
-  
+
   this.isVector = false;
 
   this.size = {rows: this.rows, cols: this.cols};
 
 };
+
+Matrix.identity = function(size) {
+  var I = new Matrix(size);
+  for (var i = 0; i < size; ++i) {
+    I.set(i, i, 1);
+  }
+  return I;
+}
 
 Matrix.prototype = {
   set : function (i, j, val) {


### PR DESCRIPTION
The Matrix constructor used the (undefined) cols variable when creating the appropriate array instead of this.cols.

There was a isIdentity parameter in the Matrix constructor but it wasn't used. I added the Matrix.identity(size).
