### PR TITLE
Fast Matrix Determinants & Benchmarking Example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -109,7 +109,6 @@ var C = A.transpose(); // C = [ [1, 3], [2, 4] ]
 ````
 
 #### calculating the determinant
-Note: only works with 2x2 or 3x3 matrices... for now.
 ```` js
 var c = A.det(); // c = -2
 ````

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -16,6 +16,12 @@ var Matrix = function Matrix (rows, cols, isIdentity) {
     }
   }
 
+  //square matrices can be declared as identities:
+  if(this.rows === this.cols && isIdentity){
+    for(var i = 0; i<this.rows; i++)
+      this.m[i][i] = 1;
+  }
+
   this.isVector = false;
 
   this.size = {rows: this.rows, cols: this.cols};
@@ -113,7 +119,39 @@ Matrix.prototype = {
       return this.m[0][0] * this.m[1][1] - this.m[0][1] * this.m[1][0];
     }
 
-    return new Error('your matrix is too big or not square or... something');
+    //try a Doolittle extraction for nxn:
+    if(this.rows === this.cols) {
+        var A, detA, detL, iter, L, l, row;
+
+        // zeroth iteration:
+        A = this;
+        L = new Matrix(this.rows, this.cols, true);
+        l = new Matrix(this.rows, this.cols);
+
+        for (iter = 1; iter < this.rows; iter++) {
+
+            // construct this iteration's lower triangular matrix:
+            l = new Matrix(this.rows, this.cols, true);
+            for (row = iter; row < this.rows; row++) {
+                l.m[row][iter - 1] = -1 * A.m[row][iter - 1] / A.m[iter - 1][iter - 1];
+                L.m[row][iter - 1] = -1 * l.m[row][iter - 1];
+            }
+
+            // update A:
+            A = l.dot(A);
+        }
+
+        detA = 1;
+        detL = 1;
+        for (iter = 0; iter < this.rows; iter++) {
+            detA = detA * A.m[iter][iter];
+            detL = detL * L.m[iter][iter];
+        }
+
+        return detA * detL;
+    }
+
+    return new Error('your matrix is not square.');
   },
 
   trace: function () {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -117,10 +117,6 @@ Matrix.prototype = {
       throw new Error('this is not a square matrix');
     }
 
-    if (this.rows === 2 && this.cols === 2) {
-      return this.m[0][0] * this.m[1][1] - this.m[0][1] * this.m[1][0];
-    }
-
     var det = 0;
     var f = 1;
     for (var i = 0; i < this.rows; i++) {

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -16,6 +16,12 @@ var Matrix = function Matrix (rows, cols, isIdentity) {
     }
   }
 
+  //square matrices can be declared as identities:
+  if(this.rows === this.cols && isIdentity){
+    for(var i = 0; i<this.rows; i++)
+      this.m[i][i] = 1;
+  }
+
   this.isVector = false;
 
   this.size = {rows: this.rows, cols: this.cols};
@@ -24,7 +30,7 @@ var Matrix = function Matrix (rows, cols, isIdentity) {
 
 Matrix.prototype = {
   set : function (i, j, val) {
-    this.m[i][j] = parseFloat(val.toFixed(6));
+    this.m[i][j] = parseFloat(val.toFixed(12));
   },
 
   setRow: function (i, vals) {
@@ -74,7 +80,7 @@ Matrix.prototype = {
       for (var i = 0; i < B.v.length; ++i) {
         arr[i] = 0;
         for (var j = 0; j < this.rows; ++j) {
-          arr[i] += parseFloat((this.get(i,j) * B.v[j]).toFixed(6));
+          arr[i] += parseFloat((this.get(i,j) * B.v[j]).toFixed(12));
         }
       }
       C = new v(arr);
@@ -84,7 +90,7 @@ Matrix.prototype = {
         for (var c = 0; c < C.cols; ++c) {
           var val = 0;
           for (var m = 0; m < B.rows; ++m) {
-             val += parseFloat((this.get(r,m) * B.get(m,c)).toFixed(6));
+             val += parseFloat((this.get(r,m) * B.get(m,c)).toFixed(12));
           }
           // console.log(val);
           C.set(r, c, val);
@@ -106,7 +112,7 @@ Matrix.prototype = {
     return T;
   },
 
-  det: function () {
+  cofactorDet: function () {
     if (this.rows !== this.cols) {
       throw new Error('this is not a square matrix');
     }
@@ -155,6 +161,48 @@ Matrix.prototype = {
       this.m[i].splice(c, 1);
     }
     this.cols -= 1;
+  },
+
+  det: function () {
+    var A, detA, detL, iter, L, l, row;
+
+    if (this.rows !== this.cols) {
+      throw new Error('this is not a square matrix');
+    }
+
+    if (this.rows === 2 && this.cols === 2) {
+      return this.m[0][0] * this.m[1][1] - this.m[0][1] * this.m[1][0];
+    }
+
+    //try a Doolittle extraction for nxn, will bail out to cofactor calculation as necessary
+    // zeroth iteration:
+    A = this;
+    L = new Matrix(this.rows, this.cols, true);
+    l = new Matrix(this.rows, this.cols);
+
+    for (iter = 1; iter < this.rows; iter++) {
+      // construct this iteration's lower triangular matrix:
+      l = new Matrix(this.rows, this.cols, true);
+      for (row = iter; row < this.rows; row++) {
+        if(A.m[iter - 1][iter - 1] === 0)
+          //bail out to the brute force calculation
+          return this.cofactorDet()
+        l.m[row][iter - 1] = -1 * A.m[row][iter - 1] / A.m[iter - 1][iter - 1];
+        L.m[row][iter - 1] = -1 * l.m[row][iter - 1];
+      }
+
+      // update A:
+      A = l.dot(A);
+    }
+
+    detA = 1;
+    detL = 1;
+    for (iter = 0; iter < this.rows; iter++) {
+      detA = detA * A.m[iter][iter];
+      detL = detL * L.m[iter][iter];
+    }
+
+    return detA * detL;
   },
 
   trace: function () {

--- a/tests/benchtest.js
+++ b/tests/benchtest.js
@@ -1,0 +1,38 @@
+//example benchmarking exercise using benchmark (npm install benchmark)
+
+var Benchmark = require('benchmark');
+var Matrix = require('../').matrix;
+
+var suite = new Benchmark.Suite;
+
+// add tests
+suite.add('cofactor det', function() {
+      var A = new Matrix(5, 5);
+      A.setRow(0, [1,2,5,4,3]);
+      A.setRow(1, [2,3,5,5,2]);
+      A.setRow(2, [2,2,5,6,1]);
+      A.setRow(3, [0,-2,1,3,2]);
+      A.setRow(4, [1,2,0,5,4]);
+
+      var determinant = A.cofactorDet();
+})
+.add('doolittle det', function(){
+      var A = new Matrix(5, 5);
+      A.setRow(0, [1,2,5,4,3]);
+      A.setRow(1, [2,3,5,5,2]);
+      A.setRow(2, [2,2,5,6,1]);
+      A.setRow(3, [0,-2,1,3,2]);
+      A.setRow(4, [1,2,0,5,4]);
+
+      var determinant = A.det();	
+})
+
+// add listeners
+.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+.on('complete', function() {
+  console.log('Fastest is ' + this.filter('fastest').pluck('name'));
+})
+// run async
+.run({ 'async': true });

--- a/tests/homog-test.js
+++ b/tests/homog-test.js
@@ -23,7 +23,7 @@ describe('Create a homogenous matrix', function () {
     var H2 = new Homog(Ry, 0);
     var H3 = new Homog(0, new Vector(1, 0, 0));
     var H2_1 = H3.dot(H2.dot(H1));
-    var s2_2 = parseFloat((Math.sqrt(2) / 2).toFixed(6));
+    var s2_2 = parseFloat((Math.sqrt(2) / 2).toFixed(12));
     H2_1.m.should.eql([[0, -s2_2, s2_2, 1], [1, 0, 0, 0], [0, s2_2, s2_2, 0], [0, 0, 0, 1]]);
   });
   it('get the location of the transformed point', function () {

--- a/tests/matrix-test.js
+++ b/tests/matrix-test.js
@@ -176,18 +176,7 @@ describe('Creating matrices: ', function () {
       A.setRow(2, [2,1,3,4]);
       A.setRow(3, [0,-2,1,3]);
 
-      A.det().should.eql(-23);
-    });
-  });
-  describe('4x4 matrix', function () {
-    it('should calculate det', function () {
-      var A = new Matrix(4, 4);
-      A.setRow(0, [3,4,4,-1]);
-      A.setRow(1, [2,1,5,3]);
-      A.setRow(2, [2,1,3,4]);
-      A.setRow(3, [0,-2,1,3]);
-
-      A.det().should.eql(-23);
+      parseFloat(A.det().toFixed(10)).should.eql(-23);
     });
   });
   describe('5x5 matrix', function () {
@@ -199,7 +188,31 @@ describe('Creating matrices: ', function () {
       A.setRow(3, [0,-2,1,3,2]);
       A.setRow(4, [1,2,0,5,4]);
 
-      A.det().should.eql(81);
+      parseFloat(A.det().toFixed(10)).should.eql(81);
+    });
+  });
+  describe('5x5 matrix', function () {
+    it('should calculate det of sparse matrix', function () {
+      var A = new Matrix(5, 5);
+      A.setRow(0, [0,0,1,0,0]);
+      A.setRow(1, [0,0,0,0,0]);
+      A.setRow(2, [0,0,0,0,0]);
+      A.setRow(3, [0,0,0,0,0]);
+      A.setRow(4, [0,0,0,0,0]);
+
+      parseFloat(A.det().toFixed(10)).should.eql(0);
+    });
+  });
+  describe('determinant validation', function () {
+    it('should get the same determinant via Doolittle or Cofactor calculation', function () {
+      var A = new Matrix(5, 5);
+      A.setRow(0, [Math.random(), Math.random(), Math.random(), Math.random(), Math.random()]);
+      A.setRow(1, [Math.random(), Math.random(), Math.random(), Math.random(), Math.random()]);
+      A.setRow(2, [Math.random(), Math.random(), Math.random(), Math.random(), Math.random()]);
+      A.setRow(3, [Math.random(), Math.random(), Math.random(), Math.random(), Math.random()]);
+      A.setRow(4, [Math.random(), Math.random(), Math.random(), Math.random(), Math.random()]);
+
+      parseFloat(A.det().toFixed(10)).should.eql(A.cofactorDet().toFixed(10));
     });
   });
   describe('not square matrix det', function () {

--- a/tests/matrix-test.js
+++ b/tests/matrix-test.js
@@ -13,7 +13,43 @@ describe('Creating matrices: ', function () {
     B.size.should.eql({rows: 2, cols: 2});
     done();
   });
+  it('should have trace === dim if identity', function (done){
+    var C = new Matrix(7,7,true),
+        D = C.trace();
+    D.should.eql(7);
+    done();
+  });
+  it('should have det === 1 if determinant of 4x4 identity', function (done){
+    var C = new Matrix(4,4,true),
+        D = C.det();
+    D.should.eql(1);
+    done();
+  });
+  it('should have det === 72 for this matrix', function (done){
+    var C = new Matrix(4,4,false),
+        D;
 
+    C.set(0,0,1);
+    C.set(0,1,2);
+    C.set(0,2,3);
+    C.set(0,3,4);
+    C.set(1,0,5);
+    C.set(1,1,6);
+    C.set(1,2,7);
+    C.set(1,3,8);
+    C.set(2,0,2);
+    C.set(2,1,6);
+    C.set(2,2,4);
+    C.set(2,3,8);
+    C.set(3,0,3);
+    C.set(3,1,1);
+    C.set(3,2,1);
+    C.set(3,3,2);
+
+    D = C.det();
+    D.should.eql(72);
+    done();
+  });
   describe('2x2 matrices: ', function () {
     var A = new Matrix(2,2);
     var B = new Matrix(2,2);


### PR DESCRIPTION
As promised, here's a speed upgrade to Vektor's determinant calculator, by way of the Doolittle algorithm.  Matrix.det() now tries this fast factorization, and falls back on the existing cofactor calculation when Doolittle fails (typically for sparse matrices).  Benchmark gave me the following results comparing Doolittle and Cofactor calculations of the 5x5 determinant from the test suite:

```
node benchtest.js 
cofactor det x 1,163 ops/sec ±0.52% (87 runs sampled)
doolittle det x 3,388 ops/sec ±0.50% (97 runs sampled)
Fastest is doolittle det 
```

So for this calculation, Doolittle runs almost triple the ops/s.

This brings us to two important points that also came up in this development:
1.  Benchmarking.  I used [benchmark](https://npmjs.org/package/benchmark), mostly because it seemed popular and worked out of the box - does anyone have an opinion on this package?  The /tests directory has an example, benchtest.js, of how to use this package; running this example will re-run the test on Doolittle v. Cofactor determinants I quoted above.  I think it would behoove us to choose a standard prescription for settling "who's fastest" contests - either benchmark or something else.
2.  Precision and testing.  I never noticed before, but prior to this PR, vektor matrices rounded their entries off to 6 decimal places.  This is fine in principle, but this rounding can compound itself in iterative calculations like Doolittle and cause tests to fail spuriously.  I assume the number 6 was chosen because people really do want at least 6 decimal places of accuracy, so I upped this to 12 decimal places, and required the determinant calculations to be accurate to 10 decimal places in the tests.  In general, we are certainly going to have to write tests with tolerances comparable to our roundoff; I erred on the side of super duper precise here, hopefully this is acceptable at least until we can agree on a prescription.
