### PR TITLE
Installs dependency benchmark.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "type": "git",
     "url": "git@github.com:rockbot/vektor.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "benchmark": "^1.0.0"
+  },
   "devDependencies": {
     "should": "2.1.1",
     "mocha": "1.15.1",


### PR DESCRIPTION
Installs dependency benchmark. I noticed that `npm test` fails after `npm install` due to this dependency missing. This change fixes the error below.

```
vektor john$ npm install
should@2.1.1 node_modules/should

underscore@1.3.3 node_modules/underscore

mocha@1.15.1 node_modules/mocha
├── diff@1.0.7
├── growl@1.7.0
├── commander@2.0.0
├── mkdirp@0.3.5
├── debug@2.1.0 (ms@0.6.2)
├── jade@0.26.3 (commander@0.6.1, mkdirp@0.3.0)
└── glob@3.2.3 (inherits@2.0.1, graceful-fs@2.0.3, minimatch@0.2.14)
vektor john$ npm test

> vektor@0.2.0 test /Users/john/vektor
> mocha tests -R spec


module.js:340
    throw err;
          ^
Error: Cannot find module 'benchmark'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/john/vektor/tests/benchtest.js:3:17)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/john/vektor/node_modules/mocha/lib/mocha.js:157:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/john/vektor/node_modules/mocha/lib/mocha.js:154:14)
    at Mocha.run (/Users/john/vektor/node_modules/mocha/lib/mocha.js:341:31)
    at Object.<anonymous> (/Users/john/vektor/node_modules/mocha/bin/_mocha:351:7)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
